### PR TITLE
Ensure uniforms are 16-byte aligned to conform with WebGL requirements

### DIFF
--- a/src/web/renderer.rs
+++ b/src/web/renderer.rs
@@ -217,7 +217,7 @@ impl State {
             resolution: [size.width as f32, size.height as f32],
             pan: [0.0, 0.0],
             zoom: 1.0,
-            _padding: 0.0,
+            _padding: [0.0, 0.0, 0.0],
         };
 
         let view_uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/src/web/renderer/edge_shader.wgsl
+++ b/src/web/renderer/edge_shader.wgsl
@@ -27,10 +27,12 @@ struct VertOut {
     @interpolate(flat) @location(10) v_hovered: u32,
 };
 
+// Required to be 16-byte aligned by WebGL
 struct ViewUniforms {
     resolution: vec2<f32>,
     pan: vec2<f32>,
     zoom: f32,
+    _padding: vec2<f32>
 };
 
 @group(0) @binding(0)

--- a/src/web/renderer/node_shader.wgsl
+++ b/src/web/renderer/node_shader.wgsl
@@ -16,10 +16,12 @@ struct VertOut {
     @interpolate(flat) @location(4) v_hovered: u32,
 };
 
+// Required to be 16-byte aligned by WebGL
 struct ViewUniforms {
     resolution: vec2<f32>,
     pan: vec2<f32>,
     zoom: f32,
+    _padding: vec2<f32>
 };
 
 @group(0) @binding(0)

--- a/src/web/renderer/radial_menu_shader.wgsl
+++ b/src/web/renderer/radial_menu_shader.wgsl
@@ -7,10 +7,12 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
+// Required to be 16-byte aligned by WebGL
 struct ViewUniforms {
     resolution: vec2<f32>,
     pan: vec2<f32>,
     zoom: f32,
+    _padding: vec2<f32>
 };
 
 struct MenuUniforms {

--- a/src/web/renderer/vertex_buffer.rs
+++ b/src/web/renderer/vertex_buffer.rs
@@ -13,7 +13,9 @@ pub struct ViewUniforms {
     pub resolution: [f32; 2],
     pub pan: [f32; 2],
     pub zoom: f32,
-    pub _padding: f32, // WGSL struct padding
+    /// WGSL struct padding.
+    /// WebGL requires the uniform to be 16-byte aligned.
+    pub _padding: [f32; 3],
 }
 
 #[repr(C)]


### PR DESCRIPTION
Fixes #26 

This is NOT tested with WebGPU as I wrote the code on Linux, where WebGPU in Firefox is not available.

Please test with WebGPU on Windows before merging.