### PR TITLE
Derive EnumIter

### DIFF
--- a/src/renderer/elements/characteristic.rs
+++ b/src/renderer/elements/characteristic.rs
@@ -1,7 +1,19 @@
 use rkyv::{Archive, Deserialize, Serialize};
 use strum::EnumIter;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Archive, Deserialize, Serialize, EnumIter, strum::Display)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Archive,
+    Deserialize,
+    Serialize,
+    EnumIter,
+    strum::Display,
+)]
 #[strum(serialize_all = "title_case")]
 pub enum Characteristic {
     Transitive,


### PR DESCRIPTION
* derive EnumIter, needed for implementing sparql snippets for ObjectProperties, which is required for https://github.com/WebVOWL/VOWL-R/issues/112