### PR TITLE
Implement element filtering

### DIFF
--- a/benches/simulator.rs
+++ b/benches/simulator.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use glam::Vec2;
-use grapher::prelude::Simulator;
+use grapher::prelude::{ElementType, OwlNode, OwlType, Simulator};
 
 /// Force-directed graph simulation speed
 fn force_directed_simulation(c: &mut Criterion) {
@@ -9,16 +9,18 @@ fn force_directed_simulation(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("Force-directed");
 
+    let mut element_types = Vec::with_capacity(nodes[4] as usize);
     let mut positions = Vec::with_capacity(nodes[4] as usize);
     let mut sizes: Vec<f32> = Vec::with_capacity(nodes[4] as usize);
     for i in nodes {
         positions.clear();
         sizes.clear();
         for _ in 0..i {
+            element_types.push(ElementType::Owl(OwlType::Node(OwlNode::Class)));
             positions.push(Vec2::new(1.0, 1.0));
             sizes.push(1.0);
         }
-        let mut simulator = Simulator::builder().build(&positions, &edges, &sizes);
+        let mut simulator = Simulator::builder().build(&element_types, &positions, &edges, &sizes);
 
         if i >= 3_000_000 {
             group.sample_size(10);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -20,7 +20,11 @@ use crate::{
         events::RenderEvent,
         node_shape::NodeShape,
     },
-    simulator::{Simulator, components::nodes::Position, ressources::events::SimulatorEvent},
+    simulator::{
+        Simulator,
+        components::nodes::{Position, Shown},
+        ressources::events::SimulatorEvent,
+    },
 };
 use glam::Vec2;
 use glyphon::{
@@ -799,7 +803,7 @@ impl State {
             }
         }
 
-        let simulator = Simulator::builder().build(&sim_nodes, &sim_edges, &sim_sizes);
+        let simulator = Simulator::builder().build(&elements, &sim_nodes, &sim_edges, &sim_sizes);
 
         // Radial menu setup
 
@@ -1993,9 +1997,16 @@ impl State {
             bytemuck::cast_slice(&[self.view_uniforms]),
         );
 
+        let mut hidden_positions = HashSet::new();
         let positions = self.simulator.world.read_storage::<Position>();
+        let shown = self.simulator.world.read_storage::<Shown>();
         let entities = self.simulator.world.entities();
-        for (i, (_, position)) in (&entities, &positions).join().enumerate() {
+
+        // Update position of all entities
+        for (i, (entity, position)) in (&entities, &positions).join().enumerate() {
+            if !shown.contains(entity) {
+                hidden_positions.insert(i);
+            }
             self.positions[i] = [position.0.x, position.0.y];
         }
 
@@ -2020,6 +2031,7 @@ impl State {
 
         let node_instances = vertex_buffer::build_node_instances(
             &self.positions,
+            Some(&hidden_positions),
             &self.elements,
             &self.node_shapes,
             self.hovered_index,
@@ -2028,6 +2040,7 @@ impl State {
         let (edge_vertices, arrow_vertices) = vertex_buffer::build_line_and_arrow_vertices(
             &self.edges,
             &self.positions,
+            Some(&hidden_positions),
             &self.node_shapes,
             &self.elements,
             self.zoom,
@@ -2466,7 +2479,8 @@ impl State {
             }
         }
 
-        self.simulator = Simulator::builder().build(&sim_nodes, &sim_edges, &sim_sizes);
+        self.simulator =
+            Simulator::builder().build(&self.elements, &sim_nodes, &sim_edges, &sim_sizes);
 
         // Regenerate text buffers
         self.text_buffers = None;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -97,6 +97,7 @@ pub struct State {
     simulator: Simulator<'static, 'static>,
     paused: bool,
     hovered_index: i32,
+    hidden_indices: HashSet<usize>,
 
     // User input
     cursor_position: Option<Vec2>,
@@ -963,6 +964,7 @@ impl State {
             simulator,
             paused: false,
             hovered_index,
+            hidden_indices: HashSet::new(),
             last_fps_time: Instant::now(),
             fps_counter: 0,
             cursor_position: None,
@@ -1489,7 +1491,7 @@ impl State {
         if let Some(text_buffers) = self.text_buffers.as_ref() {
             for (i, buf) in text_buffers.iter().enumerate() {
                 // Skip hidden nodes
-                if i >= self.elements.len() {
+                if i >= self.elements.len() || self.hidden_indices.contains(&i) {
                     continue;
                 }
 
@@ -1566,6 +1568,10 @@ impl State {
                 let edge = self.edges[*edge_idx];
                 let center_idx = edge[1];
                 let end_idx = edge[2];
+
+                if edge.iter().any(|i| self.hidden_indices.contains(i)) {
+                    continue;
+                }
 
                 let center_log_world =
                     Vec2::new(self.positions[center_idx][0], self.positions[center_idx][1]);
@@ -1669,6 +1675,7 @@ impl State {
             for (list_idx, (node_idx, buf)) in count_buffers.iter().enumerate() {
                 if *node_idx >= self.positions.len()
                     || matches!(self.elements[*node_idx], ElementType::NoDraw)
+                    || self.hidden_indices.contains(node_idx)
                 {
                     continue;
                 }
@@ -1997,7 +2004,7 @@ impl State {
             bytemuck::cast_slice(&[self.view_uniforms]),
         );
 
-        let mut hidden_positions = HashSet::new();
+        self.hidden_indices.clear();
         let positions = self.simulator.world.read_storage::<Position>();
         let shown = self.simulator.world.read_storage::<Shown>();
         let entities = self.simulator.world.entities();
@@ -2005,7 +2012,7 @@ impl State {
         // Update position of all entities
         for (i, (entity, position)) in (&entities, &positions).join().enumerate() {
             if !shown.contains(entity) {
-                hidden_positions.insert(i);
+                self.hidden_indices.insert(i);
             }
             self.positions[i] = [position.0.x, position.0.y];
         }
@@ -2031,7 +2038,7 @@ impl State {
 
         let node_instances = vertex_buffer::build_node_instances(
             &self.positions,
-            Some(&hidden_positions),
+            Some(&self.hidden_indices),
             &self.elements,
             &self.node_shapes,
             self.hovered_index,
@@ -2040,7 +2047,7 @@ impl State {
         let (edge_vertices, arrow_vertices) = vertex_buffer::build_line_and_arrow_vertices(
             &self.edges,
             &self.positions,
-            Some(&hidden_positions),
+            Some(&self.hidden_indices),
             &self.node_shapes,
             &self.elements,
             self.zoom,
@@ -2075,6 +2082,25 @@ impl State {
                 bytemuck::cast_slice(&[uniforms]),
             );
         }
+
+        self.queue.write_buffer(
+            &self.edge_vertex_buffer,
+            0,
+            &vec![0; self.edge_vertex_buffer.size() as usize],
+        );
+        self.queue.write_buffer(
+            &self.arrow_vertex_buffer,
+            0,
+            &vec![0; self.arrow_vertex_buffer.size() as usize],
+        );
+        self.queue.write_buffer(
+            &self.node_instance_buffer,
+            0,
+            &vec![0; self.node_instance_buffer.size() as usize],
+        );
+
+        self.num_edge_vertices = edge_vertices.len() as u32;
+        self.num_arrow_vertices = arrow_vertices.len() as u32;
 
         self.queue.write_buffer(
             &self.edge_vertex_buffer,
@@ -2751,7 +2777,7 @@ impl State {
         // Iterate backwards to prioritize nodes drawn "on top"
         for (i, pos_array) in self.positions.iter().enumerate().rev() {
             // Skip nodes that aren't drawn
-            if matches!(self.elements[i], ElementType::NoDraw) {
+            if matches!(self.elements[i], ElementType::NoDraw) || self.hidden_indices.contains(&i) {
                 continue;
             }
 

--- a/src/renderer/vertex_buffer.rs
+++ b/src/renderer/vertex_buffer.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use wgpu::util::DeviceExt;
 
 use crate::renderer::{
@@ -107,6 +109,7 @@ impl NodeInstance {
 
 pub fn build_node_instances(
     positions: &[[f32; 2]],
+    hidden_positions: Option<&HashSet<usize>>,
     elements: &[ElementType],
     node_shapes: &[NodeShape],
     hovered_index: i32,
@@ -115,6 +118,12 @@ pub fn build_node_instances(
     let n = positions.len() as f32;
 
     for (i, pos) in positions.iter().enumerate() {
+        if let Some(hidden) = hidden_positions
+            && hidden.contains(&i)
+        {
+            continue;
+        }
+
         let (shape_type, shape_dim) = match node_shapes[i] {
             NodeShape::Circle { r } => (0, [r, 0.0]),
             NodeShape::Rectangle { w, h } => (1, [w, h]),
@@ -149,7 +158,8 @@ pub fn create_node_instance_buffer(
     node_shapes: &[NodeShape],
     hovered_index: i32,
 ) -> wgpu::Buffer {
-    let node_instances = build_node_instances(positions, elements, node_shapes, hovered_index);
+    let node_instances =
+        build_node_instances(positions, None, elements, node_shapes, hovered_index);
     device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("instance_node_buffer"),
         contents: bytemuck::cast_slice(&node_instances),
@@ -230,6 +240,7 @@ fn normalize(v: [f32; 2]) -> [f32; 2] {
 pub fn build_line_and_arrow_vertices(
     edges: &[[usize; 3]],
     node_positions: &[[f32; 2]],
+    hidden_node_positions: Option<&HashSet<usize>>,
     node_shapes: &[NodeShape],
     elements: &[ElementType],
     zoom: f32,
@@ -247,6 +258,14 @@ pub fn build_line_and_arrow_vertices(
     let radius_pix = 50.0;
 
     for &[start_idx, center_idx, end_idx] in edges {
+        if let Some(hidden) = hidden_node_positions
+            && (hidden.contains(&start_idx)
+                || hidden.contains(&center_idx)
+                || hidden.contains(&end_idx))
+        {
+            continue;
+        }
+
         let mut start = node_positions[start_idx];
         let center = node_positions[center_idx];
         let mut end = node_positions[end_idx];
@@ -577,6 +596,7 @@ pub fn create_edge_vertex_buffer(
     let (line_vertices, arrow_vertices) = build_line_and_arrow_vertices(
         edges,
         node_positions,
+        None,
         node_shapes,
         elements,
         zoom,

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -1,14 +1,16 @@
 pub mod components;
 pub mod ressources;
 mod systems;
-use crate::prelude::EVENT_DISPATCHER;
+use crate::prelude::{EVENT_DISPATCHER, ElementType};
+use crate::simulator::components::nodes::{Fixed, NodeType, Shown};
+use crate::simulator::systems::visibility_update::{VisibilitySystemData, update_visibility};
 use crate::{
     quadtree::{BoundingBox2D, QuadTree},
     simulator::{
         components::{
             edges::Connects,
             forces::NodeForces,
-            nodes::{Degree, Mass, NodeState, Position, Velocity},
+            nodes::{Degree, Mass, Position, Velocity},
         },
         ressources::{
             events::SimulatorEvent,
@@ -79,6 +81,8 @@ type EventSystemData<'a> = (
     Write<'a, Damping>,
     Write<'a, QuadTreeTheta>,
     Write<'a, FreezeThreshold>,
+    ReadStorage<'a, Fixed>,
+    Read<'a, LazyUpdate>,
 );
 
 pub struct Simulator<'a, 'b> {
@@ -109,6 +113,8 @@ impl Simulator<'_, '_> {
             mut damping,
             mut quadtree_theta,
             mut freeze_threshold,
+            fixed,
+            updater,
         ) = event_data;
 
         let mut event_received = false;
@@ -156,13 +162,17 @@ impl Simulator<'_, '_> {
                         sys_dragging(dragging_data);
                     }
                 }
+                SimulatorEvent::HideEntities(element_checks) => {
+                    let visibility_data: VisibilitySystemData = world.system_data();
+                    update_visibility(visibility_data, element_checks);
+                }
             }
         }
         if event_received {
-            let mut node_states: WriteStorage<NodeState> = world.system_data();
+            let entities = world.entities();
 
-            (&mut node_states).par_join().for_each(|state| {
-                state.fixed = false;
+            (&entities, &fixed).join().for_each(|(entity, _)| {
+                updater.remove::<Fixed>(entity);
             });
         }
     }
@@ -259,11 +269,15 @@ impl SimulatorBuilder {
     /// Constructs a instance of `Simulator`
     pub fn build<'a, 'b>(
         self,
+        element_types: &[ElementType],
         nodes: &[Vec2],
         edges: &[[u32; 2]],
         sizes: &[f32],
     ) -> Simulator<'a, 'b> {
         let mut world = World::new();
+        // Register manually as NodeType is not included in a System.
+        world.register::<NodeType>();
+
         let mut dispatcher = DispatcherBuilder::new()
             .with(QuadTreeConstructor, "quadtree_constructor", &[])
             .with(
@@ -294,7 +308,7 @@ impl SimulatorBuilder {
             .build();
 
         dispatcher.setup(&mut world);
-        Self::create_entities(&mut world, nodes, edges, sizes);
+        Self::create_entities(&mut world, element_types, nodes, edges, sizes);
         world.maintain();
         Self::build_degrees(&world);
         self.add_ressources(&mut world);
@@ -316,7 +330,13 @@ impl SimulatorBuilder {
         world.insert(PointIntersection::default());
     }
 
-    fn create_entities(world: &mut World, nodes: &[Vec2], edges: &[[u32; 2]], sizes: &[f32]) {
+    fn create_entities(
+        world: &mut World,
+        element_types: &[ElementType],
+        nodes: &[Vec2],
+        edges: &[[u32; 2]],
+        sizes: &[f32],
+    ) {
         let mut node_entities = Vec::with_capacity(nodes.len());
 
         // Create node entities
@@ -327,7 +347,8 @@ impl SimulatorBuilder {
                 .with(Velocity::default())
                 .with(Mass(sizes[i]))
                 .with(NodeForces::default())
-                .with(NodeState::default())
+                .with(Shown)
+                .with(NodeType(element_types[i]))
                 .build();
             node_entities.push(node_entity);
         }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -361,9 +361,18 @@ impl SimulatorBuilder {
             } else {
                 let new_connects = Connects {
                     targets: vec![node_entities[edge[1] as usize]],
+                    sources: Vec::new(),
                 };
                 edge_components.insert(edge[0], new_connects);
             }
+            edge_components
+                .entry(edge[1])
+                .or_insert(Connects {
+                    targets: Vec::new(),
+                    sources: Vec::new(),
+                })
+                .sources
+                .push(node_entities[edge[0] as usize]);
         }
 
         // Add edge components to node entities

--- a/src/simulator/components/edges.rs
+++ b/src/simulator/components/edges.rs
@@ -9,28 +9,3 @@ use specs::{Component, Entity, VecStorage};
 pub struct Connects {
     pub targets: Vec<Entity>,
 }
-
-// /// How strong the spring force of an edge should be.
-// #[derive(Component)]
-// #[storage(VecStorage)]
-// pub struct SpringStiffness(pub f32);
-
-// impl Default for SpringStiffness {
-//     fn default() -> Self {
-//         Self(1.0)
-//     }
-// }
-
-// /// Length of an edge in neutral position.
-// ///
-// /// If edge is shorter than neutral it pushers apart.
-// /// If edge is longer than neutral it pulls together.
-// #[derive(Component)]
-// #[storage(VecStorage)]
-// pub struct SpringNeutralLength(pub f32);
-
-// impl Default for SpringNeutralLength {
-//     fn default() -> Self {
-//         Self(2.0)
-//     }
-// }

--- a/src/simulator/components/edges.rs
+++ b/src/simulator/components/edges.rs
@@ -4,8 +4,9 @@ use specs::{Component, Entity, VecStorage};
 
 /// Vector of edges from one source to (potentially) multiple targets.
 /// Source is implicitly the node from which this component is accessed.
-#[derive(Component)]
+#[derive(Component, Debug)]
 #[storage(VecStorage)]
 pub struct Connects {
     pub targets: Vec<Entity>,
+    pub sources: Vec<Entity>,
 }

--- a/src/simulator/components/nodes.rs
+++ b/src/simulator/components/nodes.rs
@@ -1,7 +1,8 @@
 //! Components which make up a node
 
+use crate::renderer::elements::element_type::ElementType;
 use glam::Vec2;
-use specs::{Component, VecStorage};
+use specs::{Component, NullStorage, VecStorage};
 
 /// The position of a node.
 #[derive(Component, Default)]
@@ -24,19 +25,36 @@ impl Default for Mass {
     }
 }
 
-#[derive(Component, Debug, Default, Clone)]
-#[storage(VecStorage)]
-pub struct NodeState {
-    pub fixed: bool,
-    pub dragged: bool,
-}
-
-impl NodeState {
-    pub const fn is_static(&self) -> bool {
-        self.fixed || self.dragged
-    }
-}
-
+/// The degree of a node, i.e., how many edges it has.
 #[derive(Component)]
 #[storage(VecStorage)]
 pub struct Degree(pub f32);
+
+/// A fixed node skips all force computation.
+#[derive(Component, Default)]
+#[storage(NullStorage)]
+pub struct Fixed;
+
+/// A dragged node has force applied by the user.
+///
+/// It skips all force computation.
+#[derive(Component, Default)]
+#[storage(NullStorage)]
+pub struct Dragged;
+
+/// A shown node is visible on screen.
+///
+/// A hidden node skips all force compute to save resources.
+#[derive(Component, Default)]
+#[storage(NullStorage)]
+pub struct Shown;
+
+#[derive(Component)]
+#[storage(VecStorage)]
+pub struct NodeType(pub ElementType);
+
+impl Default for NodeType {
+    fn default() -> Self {
+        Self(ElementType::NoDraw)
+    }
+}

--- a/src/simulator/ressources/events.rs
+++ b/src/simulator/ressources/events.rs
@@ -1,6 +1,8 @@
 //! Event channels for communicating with the simulator from the outside.
 
+use crate::renderer::elements::element_type::ElementType;
 use glam::Vec2;
+use std::collections::HashMap;
 
 /// Describes an event received by a [`Simulator`].
 #[derive(Clone, PartialEq)]
@@ -40,4 +42,13 @@ pub enum SimulatorEvent {
 
     /// The position of the dragged node has changed.
     Dragged(Vec2),
+
+    /// Update the visibility of entities.
+    ///
+    /// Elements that are false in the map are hidden from view.
+    ///
+    /// Any entity that is left in an invalid state due to other
+    /// entities becoming hidden are removed as well.
+    /// For instance, if the domain of an edge is removed, the edge is too.
+    HideEntities(HashMap<ElementType, bool>),
 }

--- a/src/simulator/ressources/simulator_vars.rs
+++ b/src/simulator/ressources/simulator_vars.rs
@@ -84,7 +84,7 @@ impl Default for QuadTreeTheta {
 
 impl Default for FreezeThreshold {
     fn default() -> Self {
-        Self(1.0)
+        Self(15.0)
     }
 }
 

--- a/src/simulator/systems.rs
+++ b/src/simulator/systems.rs
@@ -1,3 +1,4 @@
 pub mod force_compute;
 pub mod position_compute;
 pub mod position_update;
+pub mod visibility_update;

--- a/src/simulator/systems/force_compute.rs
+++ b/src/simulator/systems/force_compute.rs
@@ -4,7 +4,7 @@ use crate::{
         components::{
             edges::Connects,
             forces::NodeForces,
-            nodes::{Degree, Mass, NodeState, Position, Velocity},
+            nodes::{Degree, Dragged, Fixed, Mass, Position, Shown, Velocity},
         },
         ressources::simulator_vars::{
             DeltaTime, GravityForce, QuadTreeTheta, RepelForce, SpringNeutralLength,
@@ -23,7 +23,9 @@ impl<'a> System<'a> for ComputeNodeForce {
         Entities<'a>,
         ReadStorage<'a, Position>,
         ReadStorage<'a, Mass>,
-        ReadStorage<'a, NodeState>,
+        ReadStorage<'a, Fixed>,
+        ReadStorage<'a, Dragged>,
+        ReadStorage<'a, Shown>,
         WriteStorage<'a, NodeForces>,
         ReadExpect<'a, QuadTree>,
         Read<'a, QuadTreeTheta>,
@@ -32,21 +34,30 @@ impl<'a> System<'a> for ComputeNodeForce {
 
     fn run(
         &mut self,
-        (entities, positions, masses, node_states, mut node_forces, quadtree, theta, repel_force): Self::SystemData,
+        (
+            entities,
+            positions,
+            masses,
+            fixed,
+            dragged,
+            shown,
+            mut node_forces,
+            quadtree,
+            theta,
+            repel_force,
+        ): Self::SystemData,
     ) {
         (
             &*entities,
             &positions,
             &masses,
             &mut node_forces,
-            &node_states,
+            &shown,
+            !&fixed,
+            !&dragged,
         )
             .par_join()
-            .for_each(|(entity, pos, mass, node_forces, state)| {
-                if state.is_static() {
-                    node_forces.0 = Vec2::ZERO;
-                    return;
-                }
+            .for_each(|(entity, pos, mass, node_forces, _, (), ())| {
                 node_forces.0 = quadtree.approximate_forces_on_body(
                     entity.id(),
                     pos.0,
@@ -67,21 +78,27 @@ impl<'a> System<'a> for ComputeGravityForce {
         Entities<'a>,
         ReadStorage<'a, Position>,
         ReadStorage<'a, Mass>,
-        ReadStorage<'a, NodeState>,
+        ReadStorage<'a, Fixed>,
+        ReadStorage<'a, Dragged>,
+        ReadStorage<'a, Shown>,
         WriteStorage<'a, NodeForces>,
         Read<'a, GravityForce>,
     );
     fn run(
         &mut self,
-        (entities, positions, masses, node_states, mut forces, gravity_force): Self::SystemData,
+        (entities, positions, masses, fixed, dragged, shown, mut forces, gravity_force): Self::SystemData,
     ) {
-        (&entities, &positions, &masses, &mut forces, &node_states)
+        (
+            &entities,
+            &positions,
+            &masses,
+            &mut forces,
+            &shown,
+            !&fixed,
+            !&dragged,
+        )
             .par_join()
-            .for_each(|(entity, pos, mass, force, state)| {
-                if state.is_static() {
-                    return;
-                }
-
+            .for_each(|(entity, pos, mass, force, _, (), ())| {
                 force.0 += -pos.0 * mass.0 * gravity_force.0;
             });
     }
@@ -92,24 +109,30 @@ pub struct ApplyNodeForce;
 impl<'a> System<'a> for ApplyNodeForce {
     type SystemData = (
         Entities<'a>,
-        ReadStorage<'a, NodeState>,
         ReadStorage<'a, NodeForces>,
         WriteStorage<'a, Velocity>,
         ReadStorage<'a, Mass>,
+        ReadStorage<'a, Fixed>,
+        ReadStorage<'a, Dragged>,
+        ReadStorage<'a, Shown>,
         Read<'a, DeltaTime>,
     );
 
     fn run(
         &mut self,
-        (entities, node_states, forces, mut velocities, masses, delta_time): Self::SystemData,
+        (entities, forces, mut velocities, masses, fixed, dragged,shown, delta_time): Self::SystemData,
     ) {
-        (&entities, &forces, &mut velocities, &masses, &node_states)
+        (
+            &entities,
+            &forces,
+            &mut velocities,
+            &masses,
+            &shown,
+            !&fixed,
+            !&dragged,
+        )
             .par_join()
-            .for_each(|(entity, force, velocity, mass, state)| {
-                if state.is_static() {
-                    return;
-                }
-
+            .for_each(|(entity, force, velocity, mass, _, (), ())| {
                 velocity.0 += force.0 / mass.0 * delta_time.0;
             });
     }
@@ -123,6 +146,7 @@ impl<'a> System<'a> for ComputeEdgeForces {
         ReadStorage<'a, Connects>,
         WriteStorage<'a, NodeForces>,
         ReadStorage<'a, Position>,
+        ReadStorage<'a, Shown>,
         Read<'a, SpringStiffness>,
         Read<'a, SpringNeutralLength>,
         ReadStorage<'a, Degree>,
@@ -135,6 +159,7 @@ impl<'a> System<'a> for ComputeEdgeForces {
             connections,
             mut forces,
             positions,
+            shown,
             spring_stiffness,
             spring_neutral_length,
             degrees,
@@ -142,40 +167,41 @@ impl<'a> System<'a> for ComputeEdgeForces {
     ) {
         let positions_storage = &positions;
 
-        let force_updates: Vec<(specs::Entity, Vec2)> = (&entities, &positions, &connections)
-            .par_join()
-            .fold(Vec::new, |mut acc, (entity, pos, connects)| {
-                let rb1 = entity;
-                for rb2 in &connects.targets {
-                    // Look up the neighbor's position
-                    if let Some(pos2_comp) = positions_storage.get(*rb2) {
-                        let pos2 = pos2_comp.0;
-                        let direction_vec = pos2 - pos.0;
+        let force_updates: Vec<(specs::Entity, Vec2)> =
+            (&entities, &positions, &connections, &shown)
+                .par_join()
+                .fold(Vec::new, |mut acc, (entity, pos, connects, _)| {
+                    let rb1 = entity;
+                    for rb2 in &connects.targets {
+                        // Look up the neighbor's position
+                        if let Some(pos2_comp) = positions_storage.get(*rb2) {
+                            let pos2 = pos2_comp.0;
+                            let direction_vec = pos2 - pos.0;
 
-                        let force_magnitude =
-                            spring_stiffness.0 * (direction_vec.length() - spring_neutral_length.0);
+                            let force_magnitude = spring_stiffness.0
+                                * (direction_vec.length() - spring_neutral_length.0);
 
-                        let du = degrees.get(rb1).map_or(1.0, |d| d.0);
-                        let dv = degrees.get(*rb2).map_or(1.0, |d| d.0);
-                        let w = if (du + dv > 200.0) {
-                            1.0 / (du * dv).sqrt().max(1.0)
-                        } else {
-                            1.0
-                        };
+                            let du = degrees.get(rb1).map_or(1.0, |d| d.0);
+                            let dv = degrees.get(*rb2).map_or(1.0, |d| d.0);
+                            let w = if (du + dv > 200.0) {
+                                1.0 / (du * dv).sqrt().max(1.0)
+                            } else {
+                                1.0
+                            };
 
-                        let spring_force =
-                            (direction_vec.normalize_or(Vec2::ZERO) * -force_magnitude) * w;
+                            let spring_force =
+                                (direction_vec.normalize_or(Vec2::ZERO) * -force_magnitude) * w;
 
-                        acc.push((rb1, -spring_force));
-                        acc.push((*rb2, spring_force));
+                            acc.push((rb1, -spring_force));
+                            acc.push((*rb2, spring_force));
+                        }
                     }
-                }
-                acc
-            })
-            .reduce(Vec::new, |mut a, b| {
-                a.extend(b);
-                a
-            });
+                    acc
+                })
+                .reduce(Vec::new, |mut a, b| {
+                    a.extend(b);
+                    a
+                });
 
         for (entity, force_vec) in force_updates {
             if let Some(force_comp) = forces.get_mut(entity) {

--- a/src/simulator/systems/position_compute.rs
+++ b/src/simulator/systems/position_compute.rs
@@ -31,12 +31,7 @@ pub fn distance(mut data: DistanceSystemData) {
             // This node contains the cursor's position.
             // It is the node being dragged.
             data.intersection.0 = i64::from(entity.id());
-
-            // info!(
-            //     "Point {0} intersect [{1}]",
-            //     data.cursor_position.0,
-            //     entity.id()
-            // );
+            break;
         }
     }
 }

--- a/src/simulator/systems/position_compute.rs
+++ b/src/simulator/systems/position_compute.rs
@@ -1,5 +1,5 @@
 use crate::simulator::{
-    components::nodes::{Mass, Position},
+    components::nodes::{Mass, Position, Shown},
     ressources::simulator_vars::{CursorPosition, PointIntersection},
 };
 use glam::Vec2;
@@ -12,6 +12,7 @@ use specs::{Entities, Join, Read, ReadStorage, Write};
 pub struct DistanceSystemData<'a> {
     entities: Entities<'a>,
     positions: ReadStorage<'a, Position>,
+    shown: ReadStorage<'a, Shown>,
     cursor_position: Read<'a, CursorPosition>,
     intersection: Write<'a, PointIntersection>,
     masses: ReadStorage<'a, Mass>,
@@ -19,7 +20,9 @@ pub struct DistanceSystemData<'a> {
 
 /// TODO: Implement using quadtree to improve performance
 pub fn distance(mut data: DistanceSystemData) {
-    for (entity, circle, mass) in (&*data.entities, &data.positions, &data.masses).join() {
+    for (entity, circle, mass, _) in
+        (&*data.entities, &data.positions, &data.masses, &data.shown).join()
+    {
         let node_radius: f32 = 48.0 * mass.0;
 
         let d = (data.cursor_position.0.x - circle.0.x).mul_add(

--- a/src/simulator/systems/position_update.rs
+++ b/src/simulator/systems/position_update.rs
@@ -1,5 +1,5 @@
 use crate::simulator::{
-    components::nodes::{NodeState, Position, Velocity},
+    components::nodes::{Dragged, Fixed, Position, Shown, Velocity},
     ressources::simulator_vars::{
         CursorPosition, Damping, DeltaTime, FreezeThreshold, PointIntersection,
     },
@@ -18,10 +18,13 @@ impl<'a> System<'a> for UpdateNodePosition {
         Entities<'a>,
         WriteStorage<'a, Position>,
         WriteStorage<'a, Velocity>,
-        WriteStorage<'a, NodeState>,
+        WriteStorage<'a, Fixed>,
+        ReadStorage<'a, Dragged>,
+        ReadStorage<'a, Shown>,
         Read<'a, DeltaTime>,
         Read<'a, Damping>,
         Read<'a, FreezeThreshold>,
+        Read<'a, LazyUpdate>,
     );
 
     fn run(
@@ -30,29 +33,41 @@ impl<'a> System<'a> for UpdateNodePosition {
             entities,
             mut positions,
             mut velocities,
-            mut node_states,
+            mut fixed,
+            dragged,
+            shown,
             delta_time,
             damping,
             freeze_threshold,
+            updater,
         ): Self::SystemData,
     ) {
-        (&entities, &mut positions, &mut velocities, &mut node_states)
+        (&entities, &mut velocities, !&fixed, !&dragged, &shown)
             .par_join()
-            .for_each(|(entity, pos, velocity, state)| {
-                // Check Freeze Threshold
-                if !state.dragged {
-                    // Automatically freeze/unfreeze based on velocity
-                    state.fixed = velocity.0.abs().length() < freeze_threshold.0;
+            .for_each(|(entity, velocity, (), (), _)| {
+                // Automatically freeze/unfreeze based on velocity
+                if velocity.0.abs().length() < freeze_threshold.0 {
+                    updater.insert(entity, Fixed);
+                    velocity.0 = Vec2::ZERO;
                 }
+            });
 
-                if !state.is_static() {
-                    velocity.0 *= damping.0;
-                    pos.0 += velocity.0 * delta_time.0;
+        (
+            &entities,
+            &mut positions,
+            &mut velocities,
+            !&fixed,
+            !&dragged,
+            &shown,
+        )
+            .par_join()
+            .for_each(|(entity, pos, velocity, (), (), _)| {
+                velocity.0 *= damping.0;
+                pos.0 += velocity.0 * delta_time.0;
 
-                    // Safety bounds
-                    if pos.0.distance(Vec2::new(0.0, 0.0)) > 10_000_000.0 {
-                        pos.0 = Vec2::new(0.0, 0.0);
-                    }
+                // Safety bounds
+                if pos.0.distance(Vec2::new(0.0, 0.0)) > 10_000_000.0 {
+                    pos.0 = Vec2::new(0.0, 0.0);
                 }
             });
     }
@@ -61,57 +76,70 @@ impl<'a> System<'a> for UpdateNodePosition {
 #[derive(SystemData)]
 pub struct DragStartSystemData<'a> {
     entities: Entities<'a>,
-    node_states: WriteStorage<'a, NodeState>,
+    fixed: ReadStorage<'a, Fixed>,
+    dragged: ReadStorage<'a, Dragged>,
+    shown: ReadStorage<'a, Shown>,
     dragged_id: Read<'a, PointIntersection>,
+    updater: Read<'a, LazyUpdate>,
 }
 
 /// A node is being dragged.
 pub fn sys_drag_start(mut data: DragStartSystemData) {
     if data.dragged_id.0 >= 0 {
+        #[expect(clippy::unwrap_used)]
+        let dragged_entity = data.entities.entity(data.dragged_id.0.try_into().unwrap());
+
+        // Prevent dragging invisible entities.
+        if !data.shown.contains(dragged_entity) {
+            return;
+        }
+
         // Unfix everything
-        (&mut data.node_states).par_join().for_each(|state| {
-            state.fixed = false;
-        });
+        (&data.entities, &data.fixed)
+            .join()
+            .for_each(|(entity, _)| {
+                data.updater.remove::<Fixed>(entity);
+            });
 
         // Set dragged state on specific node
-        #[expect(clippy::unwrap_used)]
-        if let Some(state) = data
-            .node_states
-            .get_mut(data.entities.entity(data.dragged_id.0.try_into().unwrap()))
-        {
-            state.dragged = true;
-        }
+        data.updater.insert(dragged_entity, Dragged);
     }
 }
 
 #[derive(SystemData)]
 pub struct DragEndSystemData<'a> {
     entities: Entities<'a>,
-    node_states: WriteStorage<'a, NodeState>,
+    dragged: ReadStorage<'a, Dragged>,
+    shown: ReadStorage<'a, Shown>,
+    updater: Read<'a, LazyUpdate>,
 }
 
 /// A node is no longer being dragged.
 pub fn sys_drag_end(mut data: DragEndSystemData) {
-    for (_, state) in (&data.entities, &mut data.node_states).join() {
-        if state.dragged {
-            state.dragged = false;
-        }
+    for (entity, _, _) in (&data.entities, &data.dragged, &data.shown).join() {
+        data.updater.remove::<Dragged>(entity);
     }
 }
 
 #[derive(specs::SystemData)]
 pub struct DraggingSystemData<'a> {
     entities: Entities<'a>,
-    node_states: ReadStorage<'a, NodeState>,
+    dragged: ReadStorage<'a, Dragged>,
+    shown: ReadStorage<'a, Shown>,
     positions: WriteStorage<'a, Position>,
     cursor_position: Read<'a, CursorPosition>,
 }
 
 /// The position of the dragged node has changed.
 pub fn sys_dragging(mut data: DraggingSystemData) {
-    for (_, pos, state) in (&data.entities, &mut data.positions, &data.node_states).join() {
-        if state.dragged {
-            pos.0 = data.cursor_position.0;
-        }
+    for (_, pos, _, _) in (
+        &data.entities,
+        &mut data.positions,
+        &data.dragged,
+        &data.shown,
+    )
+        .join()
+    {
+        pos.0 = data.cursor_position.0;
     }
 }

--- a/src/simulator/systems/visibility_update.rs
+++ b/src/simulator/systems/visibility_update.rs
@@ -1,0 +1,62 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::renderer::elements::element_type::ElementType;
+use crate::simulator::components::edges::Connects;
+use crate::simulator::components::nodes::{NodeType, Shown};
+use crate::simulator::{
+    components::nodes::{Dragged, Fixed, Position, Velocity},
+    ressources::simulator_vars::{
+        CursorPosition, Damping, DeltaTime, FreezeThreshold, PointIntersection,
+    },
+};
+use glam::Vec2;
+use log::info;
+use rayon::prelude::*;
+use specs::prelude::*;
+use specs::{Entities, Join, ParJoin, Read, ReadStorage, WriteStorage, shred};
+
+#[derive(SystemData)]
+pub struct VisibilitySystemData<'a> {
+    entities: Entities<'a>,
+    node_types: ReadStorage<'a, NodeType>,
+    connects: ReadStorage<'a, Connects>,
+    updater: Read<'a, LazyUpdate>,
+}
+
+/// Show/hide entities
+pub fn update_visibility(
+    mut data: VisibilitySystemData,
+    element_checks: HashMap<ElementType, bool>,
+) {
+    let should_hide = element_checks
+        .into_iter()
+        .filter(|&(_, checked)| !checked)
+        .map(|(element, _)| element)
+        .collect::<HashSet<_>>();
+
+    /// Check all nodes having edges (incl. the edges)
+    (&data.entities, &data.node_types, &data.connects)
+        .par_join()
+        .for_each(|(entity, node_type, connect)| {
+            if should_hide.contains(&node_type.0) {
+                data.updater.remove::<Shown>(entity);
+
+                for edge in &connect.targets {
+                    data.updater.remove::<Shown>(*edge);
+                }
+            } else {
+                data.updater.insert(entity, Shown);
+            }
+        });
+
+    /// Check solitary nodes (no edges).
+    (&data.entities, &data.node_types, !&data.connects)
+        .par_join()
+        .for_each(|(entity, node_type, ())| {
+            if should_hide.contains(&node_type.0) {
+                data.updater.remove::<Shown>(entity);
+            } else {
+                data.updater.insert(entity, Shown);
+            }
+        });
+}

--- a/src/simulator/systems/visibility_update.rs
+++ b/src/simulator/systems/visibility_update.rs
@@ -41,10 +41,22 @@ pub fn update_visibility(
             if should_hide.contains(&node_type.0) {
                 data.updater.remove::<Shown>(entity);
 
-                for edge in &connect.targets {
-                    data.updater.remove::<Shown>(*edge);
+                if node_type.0.is_node() {
+                    for edge in connect.targets.iter().chain(connect.sources.iter()) {
+                        data.updater.remove::<Shown>(*edge);
+                    }
                 }
-            } else {
+            } else if node_type.0.is_node()
+                || !connect
+                    .targets
+                    .iter()
+                    .chain(connect.sources.iter())
+                    .any(|connnection| {
+                        data.node_types
+                            .get(*connnection)
+                            .is_some_and(|connected_type| should_hide.contains(&connected_type.0))
+                    })
+            {
                 data.updater.insert(entity, Shown);
             }
         });


### PR DESCRIPTION
Filtering elements here instead of in VOWLGrapher allows us to filter elements not present in the database. For instance, externals or elements generated by the serializer.

As a bonus, this is orders of magnitude faster than the previous SPARQL approach.

Depends on https://github.com/WebVOWL/VOWLGrapher/pull/234