### PR TITLE
Optimize quadtree further

### DIFF
--- a/benches/quadtree.rs
+++ b/benches/quadtree.rs
@@ -32,7 +32,7 @@ fn quadtree_insert(c: &mut Criterion) {
 fn quadtree_barnes_hut(c: &mut Criterion) {
     const THETA: f32 = 1.0;
     const REPEL_FORCE: f32 = -1e8;
-    const NODES: [u32; 5] = [3_000, 30_000, 300_000, 3_000_000, 30_000_000];
+    const NODES: [usize; 5] = [3_000, 30_000, 300_000, 3_000_000, 30_000_000];
 
     let w = 1000.0;
     let bb = BoundingBox2D::new(Vec2::ZERO, w, w);
@@ -54,7 +54,7 @@ fn quadtree_barnes_hut(c: &mut Criterion) {
             .expect("Insert should succeed");
         }
 
-        group.throughput(criterion::Throughput::Elements(u64::from(i)));
+        group.throughput(criterion::Throughput::Elements(i as u64));
         group.bench_function(BenchmarkId::new("Barnes-Hut", i), |b| {
             b.iter(|| {
                 qt.approximate_forces_on_body(

--- a/src/quadtree.rs
+++ b/src/quadtree.rs
@@ -8,7 +8,7 @@ use std::{
     ops::Range,
 };
 const EPSILON: f32 = 1e-3;
-const UNINITIALIZED: u32 = u32::MAX;
+const UNINITIALIZED: usize = usize::MAX;
 
 /// The dimension of the quadtree
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -70,24 +70,24 @@ impl BoundingBox2D {
 #[derive(Debug)]
 pub enum Node {
     Root {
-        indices: [u32; 4],
+        indices: [usize; 4],
         mass: f32,
         pos: Vec2,
     },
     Leaf {
         mass: f32,
         pos: Vec2,
-        id: u32, // Not Option<u32> to save 8 bytes on each Leaf
+        id: usize, // Not Option<u32> to save 8 bytes on each Leaf
     },
 }
 
 impl Node {
     #[must_use]
-    const fn new_leaf(pos: Vec2, mass: f32, id: u32) -> Self {
+    const fn new_leaf(pos: Vec2, mass: f32, id: usize) -> Self {
         Self::Leaf { mass, pos, id }
     }
     #[must_use]
-    const fn new_root(pos: Vec2, mass: f32, indices: [u32; 4]) -> Self {
+    const fn new_root(pos: Vec2, mass: f32, indices: [usize; 4]) -> Self {
         Self::Root { indices, mass, pos }
     }
 
@@ -117,7 +117,7 @@ impl Node {
     }
 
     #[must_use]
-    pub const fn id(&self) -> Option<u32> {
+    pub const fn id(&self) -> Option<usize> {
         match self {
             Self::Root { .. } => None,
             Self::Leaf { id, .. } => Some(*id),
@@ -128,18 +128,18 @@ impl Node {
 #[derive(Debug, Default)]
 /// A quadtree capable of storing [`u32::MAX`] elements.
 pub struct QuadTree {
-    children: HashMap<u32, Node>,
+    children: Vec<Node>,
     pub boundary: BoundingBox2D,
-    root: u32,
+    root: usize,
 }
 
 impl QuadTree {
     #[must_use]
-    pub fn new(boundary: BoundingBox2D) -> Self {
+    pub const fn new(boundary: BoundingBox2D) -> Self {
         Self {
             root: 0,
             boundary,
-            children: HashMap::new(),
+            children: Vec::new(),
         }
     }
 
@@ -148,17 +148,17 @@ impl QuadTree {
         Self {
             root: 0,
             boundary,
-            children: HashMap::with_capacity(capacity),
+            children: Vec::with_capacity(capacity),
         }
     }
 
     pub fn insert(&mut self, new_pos: Vec2, new_mass: f32) -> Result<(), String> {
-        self.insert_id(self.children.len() as u32, new_pos, new_mass)
+        self.insert_id(self.children.len(), new_pos, new_mass)
     }
 
     /// Inserts a new point with a unique ID into the quadtree.
-    pub fn insert_id(&mut self, uid: u32, new_pos: Vec2, new_mass: f32) -> Result<(), String> {
-        if self.children.len() == (UNINITIALIZED - 1) as usize {
+    pub fn insert_id(&mut self, uid: usize, new_pos: Vec2, new_mass: f32) -> Result<(), String> {
+        if self.children.len() == (UNINITIALIZED - 1) {
             return Err(format!(
                 "Quadtree is full! (storing {}/{} elements)",
                 self.children.len(),
@@ -169,20 +169,20 @@ impl QuadTree {
         // With only one node there's no need to continue
         if self.children.is_empty() {
             let new_leaf = Node::new_leaf(new_pos, new_mass, uid);
-            self.children.insert(self.children.len() as u32, new_leaf);
+            self.children.push(new_leaf);
             return Ok(());
         }
 
         let mut bb = self.boundary.clone();
         let mut root_index = self.root;
-        let new_index = self.children.len() as u32;
+        let new_index = self.children.len();
 
         // Traversing the tree until we find an empty quadrant for the new leaf.
         while let Node::Root {
             indices, mass, pos, ..
         } = &mut self
             .children
-            .get_mut(&root_index)
+            .get_mut(root_index)
             .ok_or_else(|| format!("Failed to get index {root_index} while inserting"))?
         {
             // Update Mass and Pos of root to account for the new leaf.
@@ -203,7 +203,7 @@ impl QuadTree {
         // If new leaf is too close to current leaf we merge
         if let Node::Leaf { mass, pos, .. } = self
             .children
-            .get_mut(&root_index)
+            .get_mut(root_index)
             .ok_or_else(|| format!("Failed to merge leaf index {root_index}: index not found"))?
             && pos.distance_squared(new_pos) < EPSILON
         {
@@ -211,19 +211,16 @@ impl QuadTree {
             return Ok(());
         }
 
-        self.children.insert(
-            self.children.len() as u32,
-            Node::new_leaf(new_pos, new_mass, uid),
-        );
+        self.children.push(Node::new_leaf(new_pos, new_mass, uid));
 
         // Create new root until leaf and new leaf are in different sections
-        while let Node::Leaf { mass, pos, id } = self.children[&root_index] {
+        while let Node::Leaf { mass, pos, id } = self.children[root_index] {
             let mut fin = false;
 
             // Pushes the old leaf to the back of the vector and inserts its index into the index array of the new root
             let old_node = Node::new_leaf(pos, mass, id);
-            let old_index = self.children.len() as u32;
-            self.children.insert(old_index, old_node);
+            let old_index = self.children.len();
+            self.children.push(old_node);
 
             let section = bb.section(pos);
             let mut ind = [UNINITIALIZED, UNINITIALIZED, UNINITIALIZED, UNINITIALIZED];
@@ -239,7 +236,7 @@ impl QuadTree {
 
             // Sets the old leaf index to the new root (thus the leaf index of the old leaf's parent now points to the new root)
             let new_root = Node::new_root(pos * mass + new_pos * new_mass, mass + new_mass, ind);
-            self.children.insert(root_index, new_root);
+            self.children[root_index] = new_root;
 
             if fin {
                 break;
@@ -253,132 +250,6 @@ impl QuadTree {
         Ok(())
     }
 
-    // /// Removes a node and all its descendants from the quadtree.
-    // fn delete_index(&mut self, index: u32) -> Result<(), String> {
-    //     let mut stack: SmallVec<[u32; 32]> = SmallVec::with_capacity(32);
-    //     stack.push(index);
-    //     let mut new_stack: SmallVec<[u32; 32]> = SmallVec::with_capacity(32);
-    //     'outer: loop {
-    //         for node_index in &stack {
-    //             let node = self.children.remove(node_index).ok_or_else(|| {
-    //                 format!("Failed to delete node at index {node_index}: index not found")
-    //             })?;
-    //             match node {
-    //                 Node::Root { indices, .. } => {
-    //                     for i in indices {
-    //                         if i != UNINITIALIZED {
-    //                             new_stack.push(i);
-    //                         }
-    //                     }
-    //                 }
-    //                 // A leaf has no descendants. Nothing to do.
-    //                 Node::Leaf { .. } => {}
-    //             }
-    //         }
-    //         if new_stack.is_empty() {
-    //             break 'outer;
-    //         }
-    //         // Clearing and swapping values to keep memory allocations.
-    //         stack.clear();
-    //         swap(&mut stack, &mut new_stack);
-    //     }
-    //     Ok(())
-    // }
-
-    // /// Unassigns the index of a leaf node in its parent, making it the uninitialized value.
-    // ///
-    // /// If an update leaves all children of a root node uninitialized, the root node is deleted.
-    // /// This proceeds recursively up towards the root of the quadtree.
-    // ///
-    // /// Note that unassigned leaf nodes are NOT deleted.
-    // fn unassign_index(
-    //     &mut self,
-    //     section: u8,
-    //     root_index: u32,
-    //     parents: &[u32],
-    // ) -> Result<(), String> {
-    //     if let Some(Node::Root { indices, pos, mass }) = &mut self.children.get_mut(&root_index) {
-    //         indices[section as usize] = UNINITIALIZED;
-
-    //         if indices.iter().all(|i| *i == UNINITIALIZED) {
-    //             // All children are uninitialized. We can delete the node.
-    //             self.delete_index(root_index);
-
-    //             let last = parents.len().saturating_sub(1);
-    //             let before_last = last.saturating_sub(1);
-
-    //             if let (Some(new_root_index), Some(new_parents)) =
-    //                 (parents.get(last), parents.get(0..before_last))
-    //             {
-    //                 // Unassign the deleted node from its parent.
-    //                 self.unassign_index(section, *new_root_index, new_parents)?;
-    //             }
-    //         }
-    //         return Ok(());
-    //     }
-
-    //     if let Some(Node::Leaf { .. }) = &self.children.get(&root_index) {
-    //         let last = parents.len().saturating_sub(1);
-    //         let before_last = last.saturating_sub(1);
-
-    //         if let (Some(new_root_index), Some(new_parents)) =
-    //             (parents.get(last), parents.get(0..before_last))
-    //         {
-    //             // Unassign the deleted node from its parent.
-    //             self.unassign_index(section, *new_root_index, new_parents)?;
-    //         }
-
-    //         return Ok(());
-    //     }
-    //     Err(format!(
-    //         "Cannot unassign index {root_index}: index not found"
-    //     ))
-    // }
-
-    // FIXME: Delete method is currently broken (it's dependencies are commented out as well)
-    // /// Removes the point `delete_pos` from the quadtree, if it exists.
-    // pub fn delete_point(&mut self, delete_pos: Vec2) -> Result<(), String> {
-    //     let Some(delete_node) = self.query_point(delete_pos) else {
-    //         return Err(format!(
-    //             "Failed to delete point '{delete_pos}': point not found"
-    //         ));
-    //     };
-
-    //     let mut parent_indices: SmallVec<[u32; 128]> = smallvec![];
-
-    //     let mut bb = self.boundary.clone();
-    //     let mut section = bb.section(delete_pos);
-    //     let mut current_index = self.root;
-    //     let del_mass = delete_node.mass();
-
-    //     // Traversing the tree until we find `delete_pos`.
-    //     while let Node::Root { indices, mass, pos } =
-    //         &mut self.children.get_mut(&current_index).ok_or_else(|| {
-    //             format!("Failed to get index {current_index} while deleting point {delete_pos}")
-    //         })?
-    //     {
-    //         // Update Mass and Pos of root to account for the removed node (when we find it).
-    //         *mass -= del_mass;
-    //         *pos -= delete_pos * del_mass;
-
-    //         parent_indices.push(current_index);
-
-    //         section = bb.section(delete_pos);
-    //         current_index = indices[section as usize];
-    //         bb = bb.sub_quadrant(section);
-    //     }
-
-    //     // The leaf node has a parent.
-    //     if !parent_indices.is_empty() {
-    //         // Set the deleted node to uninitialized in the parent node.
-    //         self.unassign_index(section, current_index, parent_indices.as_slice())?;
-    //     }
-
-    //     self.delete_index(current_index)?;
-
-    //     Ok(())
-    // }
-
     /// Returns the quadtree node within a `threshold` distance to position `query_pos`.
     #[must_use]
     pub fn query_point(&self, query_pos: Vec2, threshold: f32) -> Option<&Node> {
@@ -386,7 +257,7 @@ impl QuadTree {
         let mut root_index = self.root;
 
         // Traversing the tree until we find `query_pos`.
-        while let Some(Node::Root { indices, pos, .. }) = &self.children.get(&root_index) {
+        while let Some(Node::Root { indices, pos, .. }) = &self.children.get(root_index) {
             let section = bb.section(query_pos);
             root_index = indices[section as usize];
 
@@ -398,10 +269,10 @@ impl QuadTree {
         }
 
         // Check the final leaf node
-        if let Some(Node::Leaf { pos, .. }) = &self.children.get(&root_index)
+        if let Some(Node::Leaf { pos, .. }) = &self.children.get(root_index)
             && pos.distance_squared(query_pos) <= threshold
         {
-            return Some(&self.children[&root_index]);
+            return Some(&self.children[root_index]);
         }
         None
     }
@@ -425,7 +296,7 @@ impl QuadTree {
     pub fn leaves(&self) -> impl Iterator {
         self.children
             .iter()
-            .filter(|(_, node)| matches!(node, Node::Leaf { .. }))
+            .filter(|node| matches!(node, Node::Leaf { .. }))
     }
 
     /// Returns the amount of root nodes in the tree.
@@ -439,20 +310,20 @@ impl QuadTree {
     pub fn roots(&self) -> impl Iterator {
         self.children
             .iter()
-            .filter(|(_, node)| matches!(node, Node::Root { .. }))
+            .filter(|node| matches!(node, Node::Root { .. }))
     }
 
     /// Returns the number of nodes in the tree.
     ///
     /// This method's runtime is O(1).
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.children.len()
     }
 
     /// Returns `true` if the tree contains no elements.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.children.is_empty()
     }
 
@@ -471,7 +342,7 @@ impl QuadTree {
     #[must_use]
     pub fn approximate_forces_on_body(
         &self,
-        uid: u32,
+        uid: usize,
         position: Vec2,
         mass: f32,
         theta: f32,
@@ -485,12 +356,12 @@ impl QuadTree {
 
         let mut s: f32 = self.boundary.width.max(self.boundary.height);
 
-        let mut stack: SmallVec<[u32; 32]> = SmallVec::new();
+        let mut stack: SmallVec<[usize; 32]> = SmallVec::new();
         stack.push(self.root);
-        let mut new_stack: SmallVec<[u32; 32]> = SmallVec::with_capacity(32);
+        let mut new_stack: SmallVec<[usize; 32]> = SmallVec::with_capacity(32);
         'outer: loop {
             for node_index in &stack {
-                let parent = &self.children[node_index];
+                let parent = &self.children[*node_index];
 
                 match parent {
                     Node::Root { indices, .. } => {
@@ -603,7 +474,7 @@ mod test {
         // Insert first node
         let n1_mass = 5.0;
         qt.insert(Vec2::new(-1.0, -1.0), n1_mass).unwrap();
-        if let Node::Leaf { mass, .. } = qt.children[&0] {
+        if let Node::Leaf { mass, .. } = qt.children[0] {
             assert_eq!(mass, n1_mass);
         } else {
             panic!("New node should be leaf")
@@ -614,17 +485,17 @@ mod test {
         let n2_mass = 30.0;
         qt.insert(Vec2::new(1.0, 1.0), n2_mass).unwrap();
         // check root node
-        assert!(qt.children[&0].is_root());
-        if let Node::Root { indices, mass, .. } = qt.children[&0] {
+        assert!(qt.children[0].is_root());
+        if let Node::Root { indices, mass, .. } = qt.children[0] {
             assert_eq!(mass, n1_mass + n2_mass);
 
             // check node0
             assert_eq!(indices[0], 2);
-            assert!(qt.children[&1].is_leaf());
+            assert!(qt.children[1].is_leaf());
 
             // check node1
             assert_eq!(indices[3], 1);
-            assert!(qt.children[&2].is_leaf());
+            assert!(qt.children[2].is_leaf());
         }
     }
 
@@ -646,64 +517,9 @@ mod test {
         assert!(qt.query_point(Vec2::new(100.0, -100.0), EPSILON).is_none());
     }
 
-    // #[test]
-    // fn test_quadtree_delete() {
-    //     let mut qt: QuadTree = QuadTree::new(BoundingBox2D::new(Vec2::ZERO, 10.0, 10.0));
-    //     // Insert first node
-    //     let n1_mass = 5.0;
-    //     let n1_pos = Vec2::new(-1.0, -1.0);
-    //     qt.insert(n1_pos, n1_mass).unwrap();
-
-    //     // Insert second node in in the same quadrant but different sub quadrant
-    //     let n2_mass = 30.0;
-    //     let n2_pos = Vec2::new(1.0, 1.0);
-    //     qt.insert(n2_pos, n2_mass).unwrap();
-
-    //     qt.delete_point(n2_pos).unwrap();
-    //     assert!(qt.leaves() == 1);
-
-    //     qt.delete_point(n1_pos).unwrap();
-    //     assert!(qt.is_empty());
-    // }
-
-    // #[ignore = "Delete doesn't remove all nodes as expected. Don't use delete until this test is passing"]
-    // #[test]
-    // fn test_quadtree_insert_delete() {
-    //     const NODES: u32 = 100_000;
-
-    //     let w = 1000.0;
-    //     let bb = BoundingBox2D::new(Vec2::ZERO, w, w);
-    //     let mut qt: QuadTree = QuadTree::new(bb);
-    //     let mut rng = StdRng::seed_from_u64(42);
-
-    //     let mut points = Vec::with_capacity(NODES as usize);
-
-    //     for _ in 0..NODES {
-    //         points.push(Vec2::new(
-    //             rng.random_range((-w / 2.0)..(w / 2.0)),
-    //             rng.random_range((-w / 2.0)..(w / 2.0)),
-    //         ));
-    //     }
-
-    //     for i in 0..NODES {
-    //         qt.insert_id(i, points[i as usize], rng.random_range(1.0..2000.0))
-    //             .unwrap();
-    //     }
-
-    //     for point in points.iter().take(NODES as usize) {
-    //         // If points are too close to each other they're merged in the tree.
-    //         // Specifically if `p1.distance_squared(p2) <= EPSILON`.
-    //         // This means that we may not be able to delete the same amount of points as we inserted.
-    //         // Therefore, we silence the error here.
-    //         let _ = qt.delete_point(*point);
-    //     }
-
-    //     assert!(qt.is_empty());
-    // }
-
     #[test]
     fn test_quadtree_barnes_hut() {
-        const NODES: u32 = 100_000;
+        const NODES: usize = 100_000;
         const THETA: f32 = 1.0;
         const REPEL_FORCE: f32 = -1e8;
         const DELTA_TIME: f32 = 0.01;
@@ -714,9 +530,9 @@ mod test {
         let mut qt: QuadTree = QuadTree::new(bb);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let mut velocities: Vec<Vec2> = Vec::with_capacity(NODES as usize);
-        let mut points = Vec::with_capacity(NODES as usize);
-        let mut masses = Vec::with_capacity(NODES as usize);
+        let mut velocities: Vec<Vec2> = Vec::with_capacity(NODES);
+        let mut points = Vec::with_capacity(NODES);
+        let mut masses = Vec::with_capacity(NODES);
 
         for _ in 0..NODES {
             points.push(Vec2::new(
@@ -728,19 +544,17 @@ mod test {
         }
 
         for i in 0..NODES {
-            qt.insert_id(i, points[i as usize], masses[i as usize])
-                .unwrap();
+            qt.insert_id(i, points[i], masses[i]).unwrap();
         }
 
         // Run Barnes-Hut for 25 iterations
         for _ in 0..25 {
             for i in 0..NODES {
-                let mass = masses[i as usize];
-                let force =
-                    qt.approximate_forces_on_body(i, points[i as usize], mass, THETA, REPEL_FORCE);
+                let mass = masses[i];
+                let force = qt.approximate_forces_on_body(i, points[i], mass, THETA, REPEL_FORCE);
 
-                velocities[i as usize] += force / mass * DELTA_TIME * DAMPING;
-                points[i as usize] += velocities[i as usize] * DELTA_TIME;
+                velocities[i] += force / mass * DELTA_TIME * DAMPING;
+                points[i] += velocities[i] * DELTA_TIME;
             }
         }
     }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -65,7 +65,7 @@ impl<'a> System<'a> for QuadTreeConstructor {
         quadtree.boundary = BoundingBox2D::new((dir / 2.0) + min, dir[0], dir[1]);
 
         for (entity, position, mass) in (&entities, &positions, &masses).join() {
-            quadtree.insert_id(entity.id(), position.0, mass.0);
+            quadtree.insert_id(entity.id() as usize, position.0, mass.0);
         }
     }
 }

--- a/src/simulator/systems/force_compute.rs
+++ b/src/simulator/systems/force_compute.rs
@@ -59,7 +59,7 @@ impl<'a> System<'a> for ComputeNodeForce {
             .par_join()
             .for_each(|(entity, pos, mass, node_forces, _, (), ())| {
                 node_forces.0 = quadtree.approximate_forces_on_body(
-                    entity.id(),
+                    entity.id() as usize,
                     pos.0,
                     mass.0,
                     theta.0,


### PR DESCRIPTION
- Use Vec instead of HashMap
  - Yields a 60% reduction in force-simulation time, according to benchmarks. 
  - Improves frame times: 80ms -> 72ms = +1.4 FPS
- Make quadtree support usize amount of elements
   - In preparation of wasm64 