### PR TITLE
Reduce bezier segment count to decrease memory usage of edge vertices

### DIFF
--- a/src/renderer/vertex_buffer.rs
+++ b/src/renderer/vertex_buffer.rs
@@ -12,7 +12,7 @@ use crate::renderer::{
 };
 
 // Number of segments to divide each Bézier curve into for strip generation
-const BEZIER_SEGMENTS: usize = 16;
+const BEZIER_SEGMENTS: usize = 12;
 
 // --- Uniforms ---
 #[repr(C)]


### PR DESCRIPTION
Reduces memory usage by 25%. 
 Seems to be the smallest amount of bezier segments to not cause edge breakups.
